### PR TITLE
Change timer durations to 30 seconds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,8 @@ class PomodoroApp extends StatelessWidget {
 }
 
 class TimerService extends ChangeNotifier {
-  static const int focusDuration = 1 * 60;
-  static const int breakDuration = 1 * 60;
+  static const int focusDuration = 30;
+  static const int breakDuration = 30;
 
   int _remainingSeconds = focusDuration;
   bool _isRunning = false;

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,17 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:pomodoro_timer/main.dart';
+import 'package:provider/provider.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Timer starts at 00:30', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (context) => TimerService(),
+        child: const PomodoroApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that our timer starts at 00:30.
+    expect(find.text('00:30'), findsOneWidget);
   });
 }


### PR DESCRIPTION
The user requested to change both focus and break durations from 1 minute to 30 seconds.
I have:
1. Updated `lib/main.dart` to set `focusDuration` and `breakDuration` to 30.
2. Updated `test/widget_test.dart` to match the new duration and test the actual app instead of the default counter.
3. Verified the change visually using a Playwright screenshot.
4. Confirmed that all tests pass.

Fixes #4

---
*PR created automatically by Jules for task [11025201503790163353](https://jules.google.com/task/11025201503790163353) started by @kkawakita-work*