### PR TITLE
Julesの言語設定を日本語に変更

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - Follow Flutter lint rules.
 - When an Issue with 'jules' label is created, analyze the requirements and create a PR.
 - Always run tests before submitting a PR.
+- All communications, PR titles, and PR descriptions must be written in Japanese. (すべてのコミュニケーション、PRのタイトル、および説明は日本語で行うこと。)


### PR DESCRIPTION
AGENTS.md に以下のルールを追加しました。
- All communications, PR titles, and PR descriptions must be written in Japanese. (すべてのコミュニケーション、PRのタイトル、および説明は日本語で行うこと。)

これにより、今後の Jules からの通知や PR が日本語で提供されるようになります。

Fixes #6

---
*PR created automatically by Jules for task [1843771134827699870](https://jules.google.com/task/1843771134827699870) started by @kkawakita-work*