### PR TITLE
タイマーの進捗方向の反転（緑：時計回り、青：反時計回り）

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -132,12 +132,9 @@ class HomeScreen extends StatelessWidget {
     
     // Calculate progress (0.0 to 1.0)
     // Calculate progress (0.0 to 1.0)
-    // Focus: Starts full (1.0) and empties to 0.0
-    // Break: Starts empty (0.0) and fills to 1.0
+    // Progress starts at 0.0 and fills to 1.0 for both Focus and Break
     final totalDuration = isFocus ? timerService.focusDuration : timerService.breakDuration;
-    final progress = isFocus 
-        ? timerService.remainingSeconds / totalDuration
-        : 1.0 - (timerService.remainingSeconds / totalDuration);
+    final progress = 1.0 - (timerService.remainingSeconds / totalDuration);
 
     return CupertinoPageScaffold(
       backgroundColor: CupertinoColors.black,
@@ -198,6 +195,7 @@ class HomeScreen extends StatelessWidget {
                         progress: progress,
                         color: statusColor,
                         backgroundColor: const Color(0xFF1C1C1E), // Dark gray for track
+                        isFocusMode: isFocus,
                       ),
                       child: Center(
                         child: Text(
@@ -316,11 +314,13 @@ class CircularTimerPainter extends CustomPainter {
   final double progress;
   final Color color;
   final Color backgroundColor;
+  final bool isFocusMode;
 
   CircularTimerPainter({
     required this.progress,
     required this.color,
     required this.backgroundColor,
+    required this.isFocusMode,
   });
 
   @override
@@ -346,10 +346,11 @@ class CircularTimerPainter extends CustomPainter {
 
     // Start at -90 degrees (12 o'clock)
     // Sweep matching progress * 2*pi
+    // Direction depends on mode: Focus is clockwise, Break is counter-clockwise
     canvas.drawArc(
       Rect.fromCircle(center: center, radius: radius),
       -3.14159 / 2, // -pi/2
-      2 * 3.14159 * progress,
+      (isFocusMode ? 1 : -1) * 2 * 3.14159 * progress,
       false,
       progressPaint,
     );
@@ -359,7 +360,8 @@ class CircularTimerPainter extends CustomPainter {
   bool shouldRepaint(covariant CircularTimerPainter oldDelegate) {
     return oldDelegate.progress != progress ||
            oldDelegate.color != color ||
-           oldDelegate.backgroundColor != backgroundColor;
+           oldDelegate.backgroundColor != backgroundColor ||
+           oldDelegate.isFocusMode != isFocusMode;
   }
 }
 


### PR DESCRIPTION
タイマーの進捗バーの動きをユーザーの要望に合わせて変更しました。

現在の仕様では、フォーカス（緑）が反時計回りに減少し、休憩（青）が時計回りに増加していましたが、これを以下のように変更しました：
- フォーカス（緑）：時計回りに増加（0%から100%へ）
- 休憩（青）：反時計回りに増加（0%から100%へ）

これにより、緑は時計回り、青は反時計回りという要望を満たし、かつ両方のモードで「進捗（経過時間）」を視覚化するように動作を統一しました。
flutter testによる機能検証およびコードレビューを完了しています。

Fixes #10

---
*PR created automatically by Jules for task [10806535664810736948](https://jules.google.com/task/10806535664810736948) started by @kkawakita-work*